### PR TITLE
fix: mobile hero polish — typing pause, footer spacing, skip link 📱

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -28,19 +28,8 @@ import { introSegments, staticIntro } from "../data/intro";
     startTypedSequence,
   } from "../scripts/typed-sequence";
 
-  // Pause once the footer covers this fraction of the viewport. Footer
-  // visibility would misfire here: on tall screens the footer is shorter
-  // than the viewport, so its own ratio reads "mostly visible" at scroll 0
-  // and would park the sequence before it ever types.
-  const FOOTER_PAUSE_COVERAGE = 0.5;
-  // On tall viewports the footer's capped height can never cover half the
-  // viewport, so also pause once the footer is fully in view — which only
-  // happens at max scroll (at scroll 0 its bottom still hangs below the
-  // viewport). Just under 1 to absorb subpixel rounding.
-  const FOOTER_PAUSE_FULL_RATIO = 0.99;
-  // Dense thresholds so the callback re-fires often enough to track the
-  // viewport-coverage boundary, which no single footer ratio maps to.
-  const COVERAGE_THRESHOLDS = Array.from({ length: 21 }, (_, i) => i / 20);
+  const PAUSE_COVERAGE = 0.25;
+  const RESUME_COVERAGE = 0.19;
 
   const host = document.querySelector<HTMLElement>(".hero");
   if (host) {
@@ -57,33 +46,40 @@ import { introSegments, staticIntro } from "../data/intro";
       const footer = document.querySelector<HTMLElement>(".site-footer");
       if (footer) {
         let pausedByFooter = false;
-        const observer = new IntersectionObserver(
-          (entries) => {
-            // Entries batch oldest → newest; only the last reflects the
-            // current state.
-            const entry = entries[entries.length - 1];
-            const rootHeight = entry.rootBounds?.height ?? window.innerHeight;
-            const coverage = entry.intersectionRect.height / rootHeight;
-            const occluded =
-              coverage >= FOOTER_PAUSE_COVERAGE ||
-              entry.intersectionRatio >= FOOTER_PAUSE_FULL_RATIO;
-            if (occluded && !pausedByFooter) {
-              pausedByFooter = true;
-              // Dim only once the sequence has actually parked (the pause
-              // takes effect at the next segment boundary), so the fade
-              // never falls over a sentence still in motion.
-              controller.pause().then(() => {
-                if (pausedByFooter) host.classList.add("typed--background");
-              });
-            } else if (!occluded && pausedByFooter) {
-              pausedByFooter = false;
-              host.classList.remove("typed--background");
-              controller.resume();
-            }
-          },
-          { threshold: COVERAGE_THRESHOLDS },
-        );
-        observer.observe(footer);
+
+        function evaluate() {
+          const top = footer!.getBoundingClientRect().top;
+          const coverage = 1 - Math.max(top, 0) / window.innerHeight;
+          if (coverage >= PAUSE_COVERAGE && !pausedByFooter) {
+            pausedByFooter = true;
+            // Dim only once the sequence has actually parked (the pause takes
+            // effect at the next segment boundary), so the fade never falls
+            // over a sentence still in motion.
+            controller.pause().then(() => {
+              if (pausedByFooter) host!.classList.add("typed--background");
+            });
+          } else if (coverage < RESUME_COVERAGE && pausedByFooter) {
+            pausedByFooter = false;
+            host!.classList.remove("typed--background");
+            controller.resume();
+          }
+        }
+
+        // Body is the parallax scroll container, so the scroll events fire
+        // there, not on window. Coalesce bursts to one read per frame.
+        let ticking = false;
+        function schedule() {
+          if (ticking) return;
+          ticking = true;
+          requestAnimationFrame(() => {
+            ticking = false;
+            evaluate();
+          });
+        }
+
+        document.body.addEventListener("scroll", schedule, { passive: true });
+        window.addEventListener("resize", schedule, { passive: true });
+        evaluate();
       }
     }
   }

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -9,7 +9,7 @@ const year = new Date().getFullYear();
 ---
 
 <footer
-  class="site-footer depth-layer -mt-[30vh] px-page-x py-page-y-sm sm:py-page-y-md"
+  class="site-footer depth-layer mt-[-20vh] px-page-x py-page-y-sm sm:py-page-y-md"
 >
   <ul class="contact-list">
     {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -56,9 +56,9 @@ body {
   font-weight: 500;
   border-radius: var(--radius-link);
   z-index: 100;
-  transform: translateY(-150%);
+  clip-path: inset(50%);
 }
 
 .skip-link:focus-visible {
-  transform: translateY(0);
+  clip-path: none;
 }


### PR DESCRIPTION
Three homepage fixes that only surfaced on mobile.

**1. Typing pause now works on mobile.** The pause rode on an `IntersectionObserver` whose coverage math reads `rootBounds`. The mobile URL bar resizes the viewport mid-scroll without re-firing the callback, so the typewriter never parked on phones. Now a scroll handler on `body` (the parallax scroll container) samples the footer's `getBoundingClientRect().top` against a fresh `innerHeight` each frame, and pauses once the footer covers a quarter of the viewport (with hysteresis on resume).

**2. Footer moved down.** `-mt-[30vh]` to `-mt-[20vh]`, so a three-line typed string no longer crowds it.

**3. Skip link stays hidden on overscroll.** Swapped `transform: translateY(-150%)` for `clip-path: inset(50%)`. The transform still rendered the link above the page, where mobile rubber-band overscroll exposed it. The clip keeps it focusable and in the tab order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
