### PR TITLE
style: nudge hero h1 line-height to 1.05

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -108,7 +108,7 @@ import { introSegments, staticIntro } from "../data/intro";
     align-self: start;
     font-family: var(--font-display);
     font-size: var(--hero-text);
-    line-height: 1;
+    line-height: 1.05;
     letter-spacing: 0;
     font-weight: 500;
     color: var(--color-fg);


### PR DESCRIPTION
Bumps the typing headline's `line-height` from `1` to `1.05` for a bit more breathing room. `1.1` overshot; `1.05` is subtle.

- Unitless value, so it scales evenly across the responsive `--hero-text` clamp — same tightness on mobile and desktop, no media query needed.
- Doesn't affect the emoji-wrapping spans (`line-height: 0`) or the `min-height: 3em` reserve, which keys off font-size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)