### PR TITLE
refactor: give the typed-string mini-syntax one home, under test 🧪

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,5 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm format:check
       - run: pnpm check
+      - run: pnpm test
       - run: pnpm build

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
+    "test": "vitest run",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },
@@ -33,6 +34,7 @@
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "typescript": "^6.0.3",
+    "vitest": "^4.1.10",
     "wrangler": "^4.107.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.12.3)(vite@7.3.6(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
       wrangler:
         specifier: ^4.107.0
         version: 4.107.0
@@ -838,6 +841,9 @@ packages:
   '@speed-highlight/core@1.2.17':
     resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
 
@@ -928,8 +934,14 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -957,6 +969,35 @@ packages:
 
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -1020,6 +1061,10 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astro@6.4.6:
     resolution: {integrity: sha512-48OBTBKR9ctbf+DQxpOuxGl8ebfn59zTuNQMBzptmG/Mi/H8IdfMSbJgGuX1I/4U6g9yazG1p4BHlf4+2hWU4Q==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
@@ -1040,6 +1085,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1087,6 +1136,9 @@ packages:
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
@@ -1215,8 +1267,15 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1863,6 +1922,9 @@ packages:
     resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -1881,6 +1943,12 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
@@ -1918,6 +1986,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.15:
     resolution: {integrity: sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -1929,6 +2000,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2121,6 +2196,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   volar-service-css@0.0.70:
     resolution: {integrity: sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==}
     peerDependencies:
@@ -2219,6 +2335,11 @@ packages:
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   workerd@1.20260701.1:
     resolution: {integrity: sha512-uF813NG09JwNRRUfJ0zBomyTslSPM810dMj9LVvkQ7RAkLrQLzAlPU8Xh/3dIqZDo2bfd7tChbf2PtqLRARRJQ==}
@@ -2899,6 +3020,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.17': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.3.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -2967,9 +3090,16 @@ snapshots:
       tailwindcss: 4.3.2
       vite: 7.3.6(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -2998,6 +3128,47 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.2': {}
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
@@ -3078,6 +3249,8 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   astro@6.4.6(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.2)(yaml@2.8.4):
     dependencies:
@@ -3182,6 +3355,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -3217,6 +3392,8 @@ snapshots:
   commander@11.1.0: {}
 
   common-ancestor-path@2.0.0: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-es@1.2.3: {}
 
@@ -3378,7 +3555,13 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   eventemitter3@5.0.4: {}
+
+  expect-type@1.4.0: {}
 
   extend@3.0.2: {}
 
@@ -4258,6 +4441,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   sisteransi@1.0.5: {}
 
   sitemap@9.0.1:
@@ -4272,6 +4457,10 @@ snapshots:
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   stream-replace-string@2.0.0: {}
 
@@ -4312,6 +4501,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.15: {}
 
   tinyexec@1.2.4: {}
@@ -4320,6 +4511,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
 
   trim-lines@3.0.1: {}
 
@@ -4453,6 +4646,33 @@ snapshots:
     optionalDependencies:
       vite: 7.3.6(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
+  vitest@4.1.10(@types/node@24.12.3)(vite@7.3.6(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.3
+    transitivePeerDependencies:
+      - msw
+
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-css-languageservice: 6.3.10
@@ -4553,6 +4773,11 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   which-pm-runs@1.1.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workerd@1.20260701.1:
     optionalDependencies:

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -23,65 +23,22 @@ import { introSegments, staticIntro } from "../data/intro";
 </div>
 
 <script>
-  import {
-    isTypedSequenceSupported,
-    startTypedSequence,
-  } from "../scripts/typed-sequence";
-
-  const PAUSE_COVERAGE = 0.25;
-  const RESUME_COVERAGE = 0.19;
+  import { mountFooterDim } from "../scripts/hero-footer-dim";
+  import { startTypedSequence } from "../scripts/typed-sequence";
+  import { isTypedSequenceSupported } from "../scripts/typed-tokens";
 
   const host = document.querySelector<HTMLElement>(".hero");
-  if (host) {
-    const reduced = window.matchMedia(
-      "(prefers-reduced-motion: reduce)",
-    ).matches;
-    // When the animation can't run, the server-rendered static intro is
-    // already showing; there's nothing to do.
-    if (!reduced && isTypedSequenceSupported()) {
-      // Usually a no-op (the `scripting: enabled` style already hides it);
-      // removal covers browsers that animate but predate that media query.
-      host.querySelector(".hero-text-static")?.remove();
-      const controller = startTypedSequence(host);
-      const footer = document.querySelector<HTMLElement>(".site-footer");
-      if (footer) {
-        let pausedByFooter = false;
+  const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-        function evaluate() {
-          const top = footer!.getBoundingClientRect().top;
-          const coverage = 1 - Math.max(top, 0) / window.innerHeight;
-          if (coverage >= PAUSE_COVERAGE && !pausedByFooter) {
-            pausedByFooter = true;
-            // Dim only once the sequence has actually parked (the pause takes
-            // effect at the next segment boundary), so the fade never falls
-            // over a sentence still in motion.
-            controller.pause().then(() => {
-              if (pausedByFooter) host!.classList.add("typed--background");
-            });
-          } else if (coverage < RESUME_COVERAGE && pausedByFooter) {
-            pausedByFooter = false;
-            host!.classList.remove("typed--background");
-            controller.resume();
-          }
-        }
-
-        // Body is the parallax scroll container, so the scroll events fire
-        // there, not on window. Coalesce bursts to one read per frame.
-        let ticking = false;
-        function schedule() {
-          if (ticking) return;
-          ticking = true;
-          requestAnimationFrame(() => {
-            ticking = false;
-            evaluate();
-          });
-        }
-
-        document.body.addEventListener("scroll", schedule, { passive: true });
-        window.addEventListener("resize", schedule, { passive: true });
-        evaluate();
-      }
-    }
+  // When the animation can't run, the server-rendered static intro is
+  // already showing; there's nothing to do.
+  if (host && !reduced && isTypedSequenceSupported()) {
+    // Usually a no-op (the `scripting: enabled` style already hides it);
+    // removal covers browsers that animate but predate that media query.
+    host.querySelector(".hero-text-static")?.remove();
+    const controller = startTypedSequence(host);
+    const footer = document.querySelector<HTMLElement>(".site-footer");
+    if (footer) mountFooterDim(host, footer, controller);
   }
 </script>
 

--- a/src/scripts/hero-footer-dim.ts
+++ b/src/scripts/hero-footer-dim.ts
@@ -1,0 +1,54 @@
+import type { TypedSequenceController } from "./typed-sequence";
+
+// Footer viewport coverage that pauses the sequence, and the (lower)
+// coverage that resumes it. The gap is hysteresis: without it, a scroll
+// position resting near one threshold would flicker pause/resume.
+const PAUSE_COVERAGE = 0.25;
+const RESUME_COVERAGE = 0.19;
+
+/**
+ * Pauses the typing sequence and dims the hero (`typed--background`) while
+ * the footer covers enough of the viewport, and resumes it on the way back
+ * up. Keeps the animation from churning behind the footer's frosted glass.
+ */
+export function mountFooterDim(
+  host: HTMLElement,
+  footer: HTMLElement,
+  controller: TypedSequenceController,
+): void {
+  let pausedByFooter = false;
+
+  function evaluate() {
+    const top = footer.getBoundingClientRect().top;
+    const coverage = 1 - Math.max(top, 0) / window.innerHeight;
+    if (coverage >= PAUSE_COVERAGE && !pausedByFooter) {
+      pausedByFooter = true;
+      // Dim only once the sequence has actually parked (the pause takes
+      // effect at the next segment boundary), so the fade never falls
+      // over a sentence still in motion.
+      controller.pause().then(() => {
+        if (pausedByFooter) host.classList.add("typed--background");
+      });
+    } else if (coverage < RESUME_COVERAGE && pausedByFooter) {
+      pausedByFooter = false;
+      host.classList.remove("typed--background");
+      controller.resume();
+    }
+  }
+
+  // Body is the parallax scroll container, so the scroll events fire
+  // there, not on window. Coalesce bursts to one read per frame.
+  let ticking = false;
+  function schedule() {
+    if (ticking) return;
+    ticking = true;
+    requestAnimationFrame(() => {
+      ticking = false;
+      evaluate();
+    });
+  }
+
+  document.body.addEventListener("scroll", schedule, { passive: true });
+  window.addEventListener("resize", schedule, { passive: true });
+  evaluate();
+}

--- a/src/scripts/typed-sequence.ts
+++ b/src/scripts/typed-sequence.ts
@@ -2,11 +2,17 @@
  * Hero typing sequence. Each segment (hello, name, job, ...) is an inline
  * <span>; the controller types the next shuffled string into the active
  * segment one grapheme at a time, then lingers, moves the baton, thinks,
- * and types again. Strings support inline `^N` pause markers (sleep N ms)
- * and raw HTML (tags emit at once; their text content types).
+ * and types again. The strings' mini-syntax (`^N` pauses, inline HTML) is
+ * parsed by typed-tokens.ts; this module owns timing, order, and the DOM.
  */
 
 import { introSegments, type SegmentId } from "../data/intro";
+import {
+  strip,
+  tokenize,
+  withBaselineHolder,
+  type Token,
+} from "./typed-tokens";
 
 /* ------------------------------- timing -------------------------------- */
 
@@ -65,11 +71,6 @@ const TYPING = "typed--typing";
 
 /* ------------------------------- types --------------------------------- */
 
-type Token =
-  | { kind: "char"; text: string }
-  | { kind: "tag"; text: string }
-  | { kind: "pause"; ms: number };
-
 interface Segment {
   readonly id: SegmentId;
   readonly el: HTMLElement;
@@ -94,28 +95,6 @@ class CancelledError extends Error {}
 
 /* ----------------------------- utilities ------------------------------- */
 
-// Guarded so importing this module never throws on browsers without
-// Intl.Segmenter (Safari < 16.4, Firefox < 125); callers check
-// isTypedSequenceSupported() and fall back to static text.
-const segmenter =
-  "Segmenter" in Intl
-    ? new Intl.Segmenter("en", { granularity: "grapheme" })
-    : null;
-
-export function isTypedSequenceSupported(): boolean {
-  return segmenter !== null;
-}
-
-function* graphemesOf(s: string): Iterable<string> {
-  if (segmenter) {
-    for (const { segment } of segmenter.segment(s)) yield segment;
-  } else {
-    // Only reachable if a caller skips the support check. Code points split
-    // some emoji sequences, but everything still types.
-    yield* Array.from(s);
-  }
-}
-
 function shuffledIndices(n: number): number[] {
   const out = Array.from({ length: n }, (_, i) => i);
   for (let i = n - 1; i > 0; i -= 1) {
@@ -123,67 +102,6 @@ function shuffledIndices(n: number): number[] {
     [out[i], out[j]] = [out[j], out[i]];
   }
   return out;
-}
-
-const PAUSE_MARKER = /^\^(\d+)/;
-
-/** Split a string into tokens for typing: graphemes, HTML tags, ^N pauses. */
-function tokenize(raw: string): Token[] {
-  const tokens: Token[] = [];
-  let i = 0;
-  let textRun = "";
-
-  const flushTextRun = () => {
-    if (!textRun) return;
-    for (const g of graphemesOf(textRun))
-      tokens.push({ kind: "char", text: g });
-    textRun = "";
-  };
-
-  while (i < raw.length) {
-    const ch = raw[i];
-    if (ch === "^") {
-      const match = PAUSE_MARKER.exec(raw.slice(i));
-      if (match) {
-        flushTextRun();
-        tokens.push({ kind: "pause", ms: parseInt(match[1], 10) });
-        i += match[0].length;
-        continue;
-      }
-    }
-    if (ch === "<") {
-      const end = raw.indexOf(">", i);
-      if (end !== -1) {
-        flushTextRun();
-        tokens.push({ kind: "tag", text: raw.slice(i, end + 1) });
-        i = end + 1;
-        continue;
-      }
-    }
-    textRun += ch;
-    i += 1;
-  }
-  flushTextRun();
-  return tokens;
-}
-
-function strip(s: string): string {
-  return s.replace(/<[^>]+>/g, "").replace(/\^\d+/g, "");
-}
-
-/**
- * The emoji <span>s render at line-height: 0 (see Hero.astro), so they
- * can't hold the line's baseline. Strings with no bare text outside their
- * tags get a zero-width space prefix so the segment still contributes
- * baseline text.
- */
-function withBaselineHolder(raw: string): string {
-  let depth = 0;
-  for (const tok of tokenize(raw)) {
-    if (tok.kind === "tag") depth += tok.text.startsWith("</") ? -1 : 1;
-    else if (tok.kind === "char" && depth === 0) return raw;
-  }
-  return `\u{200B}${raw}`;
 }
 
 function lingerFor(lastTyped: string): number {
@@ -207,7 +125,7 @@ function thinkFor(nextStr: string, fromId: SegmentId): number {
   return THINK_BASE + lengthBonus + segBonus;
 }
 
-/** ±50% jitter around `base` ms-per-char so typing feels less mechanical. */
+/** Stretch `base` ms-per-char by 0–50% so typing feels less mechanical. */
 function humanize(base: number): number {
   return base + Math.round((Math.random() * base) / 2);
 }

--- a/src/scripts/typed-tokens.test.ts
+++ b/src/scripts/typed-tokens.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { strip, tokenize, withBaselineHolder } from "./typed-tokens";
+
+describe("tokenize", () => {
+  it("splits plain text into one char token per grapheme", () => {
+    expect(tokenize("Hi.")).toEqual([
+      { kind: "char", text: "H" },
+      { kind: "char", text: "i" },
+      { kind: "char", text: "." },
+    ]);
+  });
+
+  it("keeps multi-code-point emoji as a single grapheme", () => {
+    expect(tokenize("🛠️")).toEqual([{ kind: "char", text: "🛠️" }]);
+    expect(tokenize("🇿🇦")).toEqual([{ kind: "char", text: "🇿🇦" }]);
+  });
+
+  it("emits ^N markers as pause tokens", () => {
+    expect(tokenize("Oh,^250 hi.")).toEqual([
+      { kind: "char", text: "O" },
+      { kind: "char", text: "h" },
+      { kind: "char", text: "," },
+      { kind: "pause", ms: 250 },
+      { kind: "char", text: " " },
+      { kind: "char", text: "h" },
+      { kind: "char", text: "i" },
+      { kind: "char", text: "." },
+    ]);
+  });
+
+  it("treats a caret without digits as literal text", () => {
+    expect(tokenize("a^b")).toEqual([
+      { kind: "char", text: "a" },
+      { kind: "char", text: "^" },
+      { kind: "char", text: "b" },
+    ]);
+  });
+
+  it("emits tags whole while their content types char by char", () => {
+    expect(tokenize("<em>flex</em>")).toEqual([
+      { kind: "tag", text: "<em>" },
+      { kind: "char", text: "f" },
+      { kind: "char", text: "l" },
+      { kind: "char", text: "e" },
+      { kind: "char", text: "x" },
+      { kind: "tag", text: "</em>" },
+    ]);
+  });
+
+  it("treats an unclosed angle bracket as literal text", () => {
+    expect(tokenize("1 < 2")).toEqual([
+      { kind: "char", text: "1" },
+      { kind: "char", text: " " },
+      { kind: "char", text: "<" },
+      { kind: "char", text: " " },
+      { kind: "char", text: "2" },
+    ]);
+  });
+
+  it("handles the empty string", () => {
+    expect(tokenize("")).toEqual([]);
+  });
+});
+
+describe("strip", () => {
+  it("returns only the visible text", () => {
+    expect(strip("I have opinions about <em>flex</em> vs <em>grid</em>.")).toBe(
+      "I have opinions about flex vs grid.",
+    );
+    expect(strip("Oh,^250 hi.")).toBe("Oh, hi.");
+  });
+
+  it("strips a tag-wrapped emoji down to the emoji", () => {
+    expect(strip("<span>👋</span>")).toBe("👋");
+  });
+});
+
+describe("withBaselineHolder", () => {
+  it("leaves strings with bare text untouched", () => {
+    expect(withBaselineHolder("Hi.")).toBe("Hi.");
+    expect(withBaselineHolder("Same same, <em>but different</em>.")).toBe(
+      "Same same, <em>but different</em>.",
+    );
+  });
+
+  it("prefixes a zero-width space when all text sits inside tags", () => {
+    expect(withBaselineHolder("<span>👋</span>")).toBe(
+      "\u{200B}<span>👋</span>",
+    );
+  });
+
+  it("prefixes a zero-width space when there is no text at all", () => {
+    expect(withBaselineHolder("")).toBe("\u{200B}");
+  });
+});

--- a/src/scripts/typed-tokens.ts
+++ b/src/scripts/typed-tokens.ts
@@ -1,0 +1,99 @@
+/*
+ * Tokenizer for the hero's typed strings. The strings (src/data/intro)
+ * use a small mini-syntax: inline `^N` markers pause typing for N ms, and
+ * raw HTML tags emit at once while their text content types. Everything
+ * here is pure so the syntax has one home — the controller in
+ * typed-sequence.ts only consumes tokens.
+ */
+
+export type Token =
+  | { kind: "char"; text: string }
+  | { kind: "tag"; text: string }
+  | { kind: "pause"; ms: number };
+
+// Guarded so importing this module never throws on browsers without
+// Intl.Segmenter (Safari < 16.4, Firefox < 125); callers check
+// isTypedSequenceSupported() and fall back to static text.
+const segmenter =
+  "Segmenter" in Intl
+    ? new Intl.Segmenter("en", { granularity: "grapheme" })
+    : null;
+
+export function isTypedSequenceSupported(): boolean {
+  return segmenter !== null;
+}
+
+function* graphemesOf(s: string): Iterable<string> {
+  if (segmenter) {
+    for (const { segment } of segmenter.segment(s)) yield segment;
+  } else {
+    // Only reachable if a caller skips the support check. Code points split
+    // some emoji sequences, but everything still types.
+    yield* Array.from(s);
+  }
+}
+
+const PAUSE_MARKER = /^\^(\d+)/;
+
+/** Split a string into tokens for typing: graphemes, HTML tags, ^N pauses. */
+export function tokenize(raw: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  let textRun = "";
+
+  const flushTextRun = () => {
+    if (!textRun) return;
+    for (const g of graphemesOf(textRun))
+      tokens.push({ kind: "char", text: g });
+    textRun = "";
+  };
+
+  while (i < raw.length) {
+    const ch = raw[i];
+    if (ch === "^") {
+      const match = PAUSE_MARKER.exec(raw.slice(i));
+      if (match) {
+        flushTextRun();
+        tokens.push({ kind: "pause", ms: parseInt(match[1], 10) });
+        i += match[0].length;
+        continue;
+      }
+    }
+    if (ch === "<") {
+      const end = raw.indexOf(">", i);
+      if (end !== -1) {
+        flushTextRun();
+        tokens.push({ kind: "tag", text: raw.slice(i, end + 1) });
+        i = end + 1;
+        continue;
+      }
+    }
+    textRun += ch;
+    i += 1;
+  }
+  flushTextRun();
+  return tokens;
+}
+
+/** The string's visible text: tags and pause markers removed. */
+export function strip(s: string): string {
+  return tokenize(s)
+    .filter((tok) => tok.kind === "char")
+    .map((tok) => tok.text)
+    .join("");
+}
+
+/**
+ * The emoji <span>s render at line-height: 0 (see Hero.astro), so they
+ * can't hold the line's baseline. Strings with no bare text outside their
+ * tags get a zero-width space prefix so the segment still contributes
+ * baseline text.
+ */
+export function withBaselineHolder(raw: string): string {
+  let depth = 0;
+  for (const tok of tokenize(raw)) {
+    if (tok.kind === "tag") depth += tok.text.startsWith("</") ? -1 : 1;
+    else if (tok.kind === "char" && depth === 0) return raw;
+  }
+  return `\u{200B}${raw}`;
+}


### PR DESCRIPTION
From the code-quality audit: the trickiest logic in the repo had no tests, and the `^N`/tag mini-syntax was implemented twice.

## Changes

- **New `src/scripts/typed-tokens.ts`** — the tokenizer (`tokenize`, `strip`, `withBaselineHolder`, `isTypedSequenceSupported`) extracted from `typed-sequence.ts`. The controller now only owns timing, order, and the DOM.
- **`strip()` derives from `tokenize()`** — previously two regexes that had to stay in lockstep with the tokenizer. The mini-syntax now has a single source of truth.
- **New `src/scripts/hero-footer-dim.ts`** — the footer pause/dim wiring moves out of Hero's inline script, matching the clipboard-copy and random-note pattern. The extraction removes the `footer!`/`host!` non-null assertions and documents the hysteresis thresholds.
- **Vitest** — 12 tests for the tokenizer (grapheme clusters, flag emoji, pause markers, tags, literal `^`/`<` fallbacks), wired into CI between `check` and `build`.
- **`humanize()` comment fixed** — the jitter is +0–50% above base, not ±50%.

No behavior changes; the animation code moved, it didn't change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)