### PR TITLE
refactor: dedupe the brand link, type scale, and data exports 🧹

### DIFF
--- a/src/components/Brand.astro
+++ b/src/components/Brand.astro
@@ -1,0 +1,16 @@
+---
+import Logo from "./Logo.astro";
+---
+
+<a href="/" class="brand" aria-label="Home">
+  <Logo class="h-(--logo-size) w-(--logo-size)" bg="black" fg="white" />
+</a>
+
+<style>
+  .brand {
+    display: inline-flex;
+    width: max-content;
+    border-radius: var(--radius-link);
+    color: var(--color-fg);
+  }
+</style>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,17 +1,20 @@
 ---
-import Logo from "./Logo.astro";
+import Brand from "./Brand.astro";
 import { introSegments, staticIntro } from "../data/intro";
 ---
 
 <div class="hero-stage depth-layer min-h-dvh">
   <section class="hero px-page-x pt-page-y-md pb-4 sm:pb-6">
-    <a href="/" class="brand" aria-label="Home">
-      <Logo class="h-(--logo-size) w-(--logo-size)" bg="black" fg="white" />
-    </a>
+    <Brand />
 
     <h1 class="hero-text" aria-label={staticIntro}>
       <span class="hero-text-static">{staticIntro}</span>
       <span class="hero-text-typing" aria-hidden="true">
+        {
+          /* set:html rather than a template .map(): the join(" ") provides
+             the inter-segment spaces that the caret's negative right margin
+             (see the ::after rule below) renders over. */
+        }
         <Fragment
           set:html={introSegments
             .map((seg) => `<span class="typed" id="seg-${seg.id}"></span>`)
@@ -95,13 +98,6 @@ import { introSegments, staticIntro } from "../data/intro";
     display: flex;
     flex-direction: column;
     row-gap: var(--hero-gap-y);
-  }
-
-  .brand {
-    display: inline-flex;
-    width: max-content;
-    border-radius: var(--radius-link);
-    color: var(--color-fg);
   }
 
   .hero-text {

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -1,22 +1,21 @@
 ---
+// Decorative: every use sits inside a link that carries its own
+// aria-label. Sized by the consumer via `class` (Tailwind utilities —
+// scoped styles in the consumer can't reach this svg).
 interface Props {
   class?: string;
   fg?: string;
   bg?: string;
-  size?: number;
 }
 
-const { class: className, fg = "currentColor", bg, size } = Astro.props;
+const { class: className, fg = "currentColor", bg } = Astro.props;
 ---
 
 <svg
   xmlns="http://www.w3.org/2000/svg"
   viewBox="0 0 1254 1254"
-  width={size}
-  height={size}
   class={className}
-  aria-label="Dale French"
-  role="img"
+  aria-hidden="true"
 >
   {bg && <rect width="1254" height="1254" fill={bg} />}
   <path

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -21,6 +21,8 @@ const year = new Date().getFullYear();
             target={link.external ? "_blank" : undefined}
             class="contact-link"
           >
+            {/* Six-per-em space: a thin, copyable gap after the label that
+                flex layout can't collapse, padding the arrow beyond `gap`. */}
             {link.label}&#8197;
             <span>
               <ArrowIcon />
@@ -47,7 +49,7 @@ const year = new Date().getFullYear();
   <section class="bookend">
     <div class="year-block">
       <a href="/" class="home-link" aria-label="Home">
-        <Logo bg="black" fg="white" size={32} />
+        <Logo class="h-8 w-8" bg="black" fg="white" />
       </a>
       <p class="year">{year}</p>
     </div>
@@ -114,7 +116,7 @@ const year = new Date().getFullYear();
   }
 
   .contact-list {
-    font-size: clamp(1.5rem, 2.5vw + 0.75rem, 2rem);
+    font-size: var(--contact-text);
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -194,7 +196,7 @@ const year = new Date().getFullYear();
   }
 
   .bookend {
-    font-size: clamp(1.125rem, 1.5vw + 0.5rem, 1.5rem);
+    font-size: var(--footnote-text);
     display: flex;
     flex-wrap: wrap;
     align-items: flex-end;

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,4 +1,6 @@
 export const GA_MEASUREMENT_ID = "G-82TXQKPXNL";
 export const SITE_TITLE = "Dale French";
+// Deliberately not `staticIntro` (src/data/intro): this is a search/social
+// snippet, so it reads warmer and names both roles up front.
 export const SITE_DESCRIPTION =
   "Hey! My name is Dale French, and I am a hands-on engineering manager and frontend engineer based in Amsterdam.";

--- a/src/data/intro/fact.ts
+++ b/src/data/intro/fact.ts
@@ -1,4 +1,4 @@
-export default [
+export const fact: readonly string[] = [
   "<span>🛠️</span>",
   "<span>🚲</span>",
   "<span>🇿🇦</span>",
@@ -27,4 +27,4 @@ export default [
   "I built my first website for Internet Explorer 6.",
   "I like riding my skateboard.",
   "I used em dashes^750 before they were a thing.",
-] as const satisfies readonly string[];
+];

--- a/src/data/intro/hello.ts
+++ b/src/data/intro/hello.ts
@@ -1,4 +1,4 @@
-export default [
+export const hello: readonly string[] = [
   "<span>👋</span>",
   "<span>✋</span>",
   "Hi.",
@@ -16,4 +16,4 @@ export default [
   "Hello there.",
   "Nice to meet you.",
   "Hey!^500 Seems you found me online.",
-] as const satisfies readonly string[];
+];

--- a/src/data/intro/index.ts
+++ b/src/data/intro/index.ts
@@ -1,10 +1,10 @@
-import hello from "./hello";
-import name from "./name";
-import job from "./job";
-import fact from "./fact";
-import live from "./live";
-import next from "./next";
-import outro from "./outro";
+import { hello } from "./hello";
+import { name } from "./name";
+import { job } from "./job";
+import { fact } from "./fact";
+import { live } from "./live";
+import { next } from "./next";
+import { outro } from "./outro";
 
 export type SegmentId =
   "hello" | "name" | "job" | "fact" | "live" | "next" | "outro";

--- a/src/data/intro/job.ts
+++ b/src/data/intro/job.ts
@@ -1,4 +1,4 @@
-export default [
+export const job: readonly string[] = [
   "I build things for the web.",
   "I’m a frontend engineer.",
   "I’m an engineering manager.",
@@ -13,4 +13,4 @@ export default [
   "I was a designer before I was an engineer.",
   "I lead a product team at a global travel company.",
   "I spend a suspicious amount of time with AI agents.",
-] as const satisfies readonly string[];
+];

--- a/src/data/intro/live.ts
+++ b/src/data/intro/live.ts
@@ -1,4 +1,4 @@
-export default [
+export const live: readonly string[] = [
   "I’m based in Amsterdam.",
   "I live in Amsterdam.",
   "I’m from South Africa.",
@@ -7,4 +7,4 @@ export default [
   "I’ve been living in Amsterdam since 2021.",
   "I swapped South African sun for Dutch drizzle.",
   "I live a short bike ride from the office.",
-] as const satisfies readonly string[];
+];

--- a/src/data/intro/name.ts
+++ b/src/data/intro/name.ts
@@ -1,8 +1,8 @@
-export default [
+export const name: readonly string[] = [
   "I’m Dale.",
   "Dale here.",
   "This is Dale.",
   "My name is Dale.",
   "I’m Dale French.",
   "Dale speaking.^500 Well,^375 typing.",
-] as const satisfies readonly string[];
+];

--- a/src/data/intro/next.ts
+++ b/src/data/intro/next.ts
@@ -1,4 +1,4 @@
-export default [
+export const next: readonly string[] = [
   "AMA.",
   "Let’s chat.",
   "Say hi back.",
@@ -7,4 +7,4 @@ export default [
   "What are you building?",
   "Want to talk AI agents?",
   "Curious what you’re working on.",
-] as const satisfies readonly string[];
+];

--- a/src/data/intro/outro.ts
+++ b/src/data/intro/outro.ts
@@ -1,4 +1,4 @@
-export default [
+export const outro: readonly string[] = [
   "<span>🤙</span>",
   "<span>🫡</span>",
   "<span>✌️</span>",
@@ -12,4 +12,4 @@ export default [
   "Have a good one.",
   "Have a lekker day.",
   "Take it easy.",
-] as const satisfies readonly string[];
+];

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,6 +1,6 @@
 ---
+import Brand from "../components/Brand.astro";
 import Layout from "../layouts/Layout.astro";
-import Logo from "../components/Logo.astro";
 import { SITE_TITLE } from "../consts";
 ---
 
@@ -9,9 +9,7 @@ import { SITE_TITLE } from "../consts";
   description="This page doesn’t exist."
 >
   <main id="main" class="not-found px-page-x pt-page-y-md">
-    <a href="/" class="brand" aria-label="Home">
-      <Logo class="h-(--logo-size) w-(--logo-size)" bg="black" fg="white" />
-    </a>
+    <Brand />
 
     <h1 class="not-found-text">
       Hmm.<br />There’s nothing here.
@@ -30,13 +28,6 @@ import { SITE_TITLE } from "../consts";
     background-color: var(--color-bg);
   }
 
-  .brand {
-    display: inline-flex;
-    width: max-content;
-    border-radius: var(--radius-link);
-    color: var(--color-fg);
-  }
-
   .not-found-text {
     font-family: var(--font-display);
     font-size: var(--hero-text);
@@ -47,7 +38,7 @@ import { SITE_TITLE } from "../consts";
 
   .not-found-link {
     font-family: var(--font-display);
-    font-size: clamp(1.125rem, 1.5vw + 0.5rem, 1.5rem);
+    font-size: var(--footnote-text);
     font-weight: 500;
   }
 

--- a/src/scripts/random-note.ts
+++ b/src/scripts/random-note.ts
@@ -8,9 +8,9 @@ const VISIBLE = "is-visible";
 export function mountRandomNote(
   bookend: HTMLElement,
   list: HTMLUListElement,
-): { destroy(): void } {
+): void {
   const items = Array.from(list.children) as HTMLElement[];
-  if (items.length === 0) return { destroy() {} };
+  if (items.length === 0) return;
 
   function pickOther(current: HTMLElement | null): HTMLElement {
     if (items.length === 1) return items[0];
@@ -33,10 +33,4 @@ export function mountRandomNote(
     current = next;
   });
   observer.observe(bookend);
-
-  return {
-    destroy() {
-      observer.disconnect();
-    },
-  };
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -5,8 +5,12 @@
   --link-outline: calc(var(--link-enlargement) / 2);
 
   --hero-gap-y: clamp(3rem, 4vw + 1.5rem, 5rem);
-  --hero-text: clamp(2.25rem, 5.5vw + 1rem, 4.5rem);
   --logo-size: clamp(3rem, 4.5vw + 1rem, 4.5rem);
+
+  /* Fluid type scale, largest to smallest. */
+  --hero-text: clamp(2.25rem, 5.5vw + 1rem, 4.5rem);
+  --contact-text: clamp(1.5rem, 2.5vw + 0.75rem, 2rem);
+  --footnote-text: clamp(1.125rem, 1.5vw + 0.5rem, 1.5rem);
 }
 
 ::selection {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"],
-  "compilerOptions": {
-    "strictNullChecks": true
-  }
+  "exclude": ["dist"]
 }


### PR DESCRIPTION
From the code-quality audit: the duplication and small-smells batch. No visual or behavior changes — verified against the built output (both logos render with class sizing, pages build clean).

## Changes

- **New `Brand.astro`** — the home link + logo markup and its `.brand` style block were copy-pasted between `Hero.astro` and `404.astro`.
- **Fluid type scale in `tokens.css`** — `clamp(1.125rem, 1.5vw + 0.5rem, 1.5rem)` appeared verbatim in the footer bookend and the 404 link, with the contact-list clamp as a third bespoke size. Now `--hero-text`, `--contact-text`, `--footnote-text` sit together, largest to smallest.
- **`Logo` gets one sizing API** — consumers size it via `class`; the footer was the only `size` prop user (`size={32}` → `h-8 w-8`). The svg is now `aria-hidden`: every use sits inside a link with its own `aria-label`, which overrode the svg's label anyway.
- **`data/intro`** — named, typed exports (`export const hello: readonly string[]`) replace the repeated `as const satisfies readonly string[]` on anonymous default exports; nothing consumed the literal types.
- **`consts.ts`** — comment explaining why `SITE_DESCRIPTION` intentionally differs from `staticIntro`, killing the drift question.
- **`tsconfig.json`** — drop `strictNullChecks: true`; `astro/tsconfigs/strict` already enables it.
- **`random-note.ts`** — drop the `destroy()` handle nothing could ever call.
- **Comments for two load-bearing subtleties** — the `set:html`/`join(" ")` inter-segment spaces the caret design depends on, and the non-collapsible `&#8197;` after contact labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)