### PR TITLE
docs: add AGENTS.md and a real README 📖

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent notes
+
+Personal portfolio site (dalefrench.dev). Astro 6 + Tailwind 4, statically
+built, served as Cloudflare Workers static assets. No client framework:
+interactivity is plain TypeScript mounted from component `<script>` tags.
+
+## Commands
+
+- `pnpm dev` / `pnpm build` / `pnpm preview`
+- `pnpm check` — astro check (type-checks `.astro` and `.ts`)
+- `pnpm test` — vitest unit tests
+- `pnpm format` / `pnpm format:check` — prettier (the only formatter)
+
+CI (`.github/workflows/ci.yml`) runs format check, type check, tests, and
+the build; all must pass.
+
+## Layout
+
+- `src/data/` — content as data: hero intro strings, contact links, footer
+  notes. Adding or editing copy is a data change only; the animation
+  sequence derives from `src/data/intro/index.ts`, so a new segment can't
+  be silently left out.
+- `src/scripts/` — framework-free TS modules, mounted from `<script>` tags
+  in components. `typed-sequence.ts` drives the hero typing animation.
+- `src/components/`, `src/layouts/`, `src/pages/` — Astro.
+- `src/styles/` — `global.css` (Tailwind theme + base), `tokens.css`
+  (design tokens), `parallax.css` (scroll effect, see gotcha below).
+
+## Gotchas
+
+- **`<body>` is the scroll container, not `window`.** The parallax effect
+  (`src/styles/parallax.css`) sets `overflow: hidden` on `html` and scrolls
+  `body` inside a 3D perspective. Scroll listeners must attach to
+  `document.body` (a `window` scroll listener never fires), and the scroll
+  position is `document.body.scrollTop`.
+- **Astro scoped styles can't reach child-component DOM.** To size or style
+  something inside a child (e.g. the svg in `Logo.astro`), pass Tailwind
+  utilities via the `class` prop or use `:global()` — a scoped selector in
+  the parent silently does nothing.
+- **Hero strings use a mini-syntax.** Strings in `src/data/intro` may
+  contain `^N` (pause typing for N ms) and inline HTML (tags emit at once;
+  their text content types out). `staticIntro` in `src/data/intro/index.ts`
+  is the canonical fallback sentence for every non-animated surface.
+- **Motion is fully progressive.** Parallax and the typing animation both
+  disable under `prefers-reduced-motion`, and the typing animation also
+  falls back to `staticIntro` without JS or `Intl.Segmenter`. Keep new
+  motion behind the same guards.
+
+## Conventions
+
+- Comments explain _why_, never _what_ — keep that bar.
+- Conventional commit messages with a trailing emoji (see `git log`).
+- This is a public repo: no secrets, no dead code, no leftover scaffolding.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
-## My personal website
+# dalefrench.dev
 
-[dalefrench.dev](https://dalefrench.dev)
+My personal website — [dalefrench.dev](https://dalefrench.dev).
+
+A single page that introduces itself: the hero types, erases, and retypes
+shuffled intro lines from a small pool, over a subtle CSS-only parallax.
+Everything degrades gracefully — no JS, reduced motion, and old browsers
+all get a static intro.
+
+## Stack
+
+- [Astro](https://astro.build) 6 with [Tailwind CSS](https://tailwindcss.com) 4
+- No client framework — interactivity is vanilla TypeScript in component scripts
+- Deployed to [Cloudflare Workers](https://workers.cloudflare.com) as static assets
+
+## Develop
+
+```sh
+pnpm install
+pnpm dev
+```
+
+`pnpm build` builds to `dist/`, `pnpm check` type-checks, `pnpm test` runs
+the unit tests, and `pnpm format` formats. CI runs all four.
+
+Working on this repo with an AI agent? Start with [AGENTS.md](AGENTS.md).
+
+## License
+
+[MIT](LICENSE). The Neue Haas Grotesk font files are licensed separately
+and are not covered.


### PR DESCRIPTION
From the code-quality audit: the repo's hard-won gotchas lived nowhere in the repo.

## Changes

- **`AGENTS.md`** — the things the code can't say for itself, aimed at anyone (human or agent) landing cold:
  - `<body>` is the scroll container, not `window` — a `window` scroll listener silently never fires
  - Astro scoped styles can't reach child-component DOM
  - the hero strings' `^N`/inline-HTML mini-syntax and the `staticIntro` fallback contract
  - the progressive-motion guards new work must stay behind
  - commands, layout, and conventions
- **`README.md`** — grows from a bare link into a short introduction: what the site does, the stack, dev setup, and licensing (font files excluded from MIT).

Note: `pnpm test` referenced here lands in #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)