### PR TITLE
feat: add dark/light theme toggle 💡

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,13 @@ the build; all must pass.
   something inside a child (e.g. the svg in `Logo.astro`), pass Tailwind
   utilities via the `class` prop or use `:global()` — a scoped selector in
   the parent silently does nothing.
+- **Nothing interactive inside the hero's depth layer.** Chromium's
+  hit-testing fails on `.hero-stage`'s large `scale(3) translateZ(-2px)`
+  transform: once the layer is composited, clicks fall through to
+  `<main>`. That's why `SiteHeader` overlays the hero from outside the
+  3D transform (with a raised `z-index`, since it's coplanar with `main`)
+  instead of living in the hero's flex column. The footer's milder layer
+  (`--depth: 0.25`) hit-tests fine.
 - **Hero strings use a mini-syntax.** Strings in `src/data/intro` may
   contain `^N` (pause typing for N ms) and inline HTML (tags emit at once;
   their text content types out). `staticIntro` in `src/data/intro/index.ts`

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -3,7 +3,7 @@
 // on the whole site.
 import "../styles/global.css";
 import { Font } from "astro:assets";
-import { GA_MEASUREMENT_ID } from "../consts";
+import { GA_MEASUREMENT_ID, THEME_COLORS } from "../consts";
 
 interface Props {
   title: string;
@@ -14,6 +14,22 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const socialImage = new URL("/og.png", Astro.site);
 
 const { title, description } = Astro.props;
+
+// Runs synchronously while the head parses, before anything can paint: an
+// explicit theme choice must land on <html> (and the theme-color metas)
+// pre-paint or the first frame flashes the system theme. No stored choice
+// means follow the system, which pure CSS already renders correctly.
+const themeInit = `
+try {
+  var t = localStorage.getItem("theme");
+  if (t === "light" || t === "dark") {
+    document.documentElement.dataset.theme = t;
+    document.querySelectorAll('meta[name="theme-color"]').forEach(function (m) {
+      m.content = t === "dark" ? "${THEME_COLORS.dark}" : "${THEME_COLORS.light}";
+    });
+  }
+} catch (e) {}
+`;
 
 const gaSnippet = `
 window.dataLayer = window.dataLayer || [];
@@ -42,7 +58,17 @@ const personSchema = {
 
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<meta name="theme-color" content="#ffffff" />
+<meta
+  name="theme-color"
+  media="(prefers-color-scheme: light)"
+  content={THEME_COLORS.light}
+/>
+<meta
+  name="theme-color"
+  media="(prefers-color-scheme: dark)"
+  content={THEME_COLORS.dark}
+/>
+<script is:inline set:html={themeInit} />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="icon" href="/favicon.ico" />
 <link rel="sitemap" href="/sitemap-index.xml" />

--- a/src/components/Brand.astro
+++ b/src/components/Brand.astro
@@ -3,7 +3,11 @@ import Logo from "./Logo.astro";
 ---
 
 <a href="/" class="brand" aria-label="Home">
-  <Logo class="h-(--logo-size) w-(--logo-size)" bg="black" fg="white" />
+  <Logo
+    class="h-(--logo-size) w-(--logo-size)"
+    bg="var(--color-fg)"
+    fg="var(--color-bg)"
+  />
 </a>
 
 <style>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -53,11 +53,8 @@ import { introSegments, staticIntro } from "../data/intro";
     flex-direction: column;
     row-gap: var(--hero-gap-y);
     /* The SiteHeader overlay renders where the brand row used to sit in
-       this flex column; reserve the same vertical run (page padding +
-       logo row + gap) so the heading doesn't move. */
-    padding-top: calc(
-      var(--spacing-page-y-md) + var(--logo-size) + var(--hero-gap-y)
-    );
+       this flex column; reserving its run keeps the heading in place. */
+    padding-top: var(--header-run);
   }
 
   .hero-text {

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,12 +1,9 @@
 ---
-import Brand from "./Brand.astro";
 import { introSegments, staticIntro } from "../data/intro";
 ---
 
 <div class="hero-stage depth-layer min-h-dvh">
-  <section class="hero px-page-x pt-page-y-md pb-4 sm:pb-6">
-    <Brand />
-
+  <section class="hero px-page-x pb-4 sm:pb-6">
     <h1 class="hero-text" aria-label={staticIntro}>
       <span class="hero-text-static">{staticIntro}</span>
       <span class="hero-text-typing" aria-hidden="true">
@@ -55,6 +52,12 @@ import { introSegments, staticIntro } from "../data/intro";
     display: flex;
     flex-direction: column;
     row-gap: var(--hero-gap-y);
+    /* The SiteHeader overlay renders where the brand row used to sit in
+       this flex column; reserve the same vertical run (page padding +
+       logo row + gap) so the heading doesn't move. */
+    padding-top: calc(
+      var(--spacing-page-y-md) + var(--logo-size) + var(--hero-gap-y)
+    );
   }
 
   .hero-text {

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -49,7 +49,7 @@ const year = new Date().getFullYear();
   <section class="bookend">
     <div class="year-block">
       <a href="/" class="home-link" aria-label="Home">
-        <Logo class="h-8 w-8" bg="black" fg="white" />
+        <Logo class="h-8 w-8" bg="var(--color-fg)" fg="var(--color-bg)" />
       </a>
       <p class="year">{year}</p>
     </div>
@@ -143,11 +143,14 @@ const year = new Date().getFullYear();
     border-radius: var(--radius-link);
     white-space: nowrap;
     cursor: pointer;
-    -webkit-tap-highlight-color: rgb(0 0 0 / 0.066);
+    -webkit-tap-highlight-color: light-dark(
+      rgb(0 0 0 / 0.066),
+      rgb(255 255 255 / 0.066)
+    );
   }
 
   .contact-link:active {
-    background-color: rgb(0 0 0 / 0.066);
+    background-color: light-dark(rgb(0 0 0 / 0.066), rgb(255 255 255 / 0.066));
   }
 
   .copy-link {

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -1,0 +1,37 @@
+---
+import Brand from "./Brand.astro";
+import ThemeToggle from "./ThemeToggle.astro";
+---
+
+{
+  /* Overlays the hero rather than living inside it: Chromium's hit-testing
+     can't resolve clicks through the hero's scaled depth layer, so anything
+     interactive has to stay outside the 3D transform. The zero-height
+     anchor keeps the header in scrolled content without pushing the hero
+     down; Hero/404 reserve its space in their own padding. */
+}
+<div class="site-header-anchor">
+  <header
+    class="site-header flex items-center justify-between px-page-x pt-page-y-md"
+  >
+    <Brand />
+    <ThemeToggle />
+  </header>
+</div>
+
+<style>
+  .site-header-anchor {
+    position: relative;
+    height: 0;
+    /* Coplanar with <main> in the body's 3D context, and main comes later
+       in the DOM, so without a raised stacking order the header paints and
+       hit-tests underneath, swallowing every click. */
+    z-index: 1;
+  }
+
+  .site-header {
+    position: absolute;
+    top: 0;
+    inset-inline: 0;
+  }
+</style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -37,6 +37,21 @@
   </svg>
 </button>
 
+<script is:inline>
+  // Mirrors resolveCurrentTheme (src/scripts/theme.ts) for one attribute:
+  // the bundled module loads late, and until it runs the button would
+  // announce as a stateless "Dark mode" button.
+  (function () {
+    var t = document.documentElement.dataset.theme;
+    var dark =
+      t === "dark" ||
+      (t !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
+    document
+      .querySelector(".theme-toggle")
+      .setAttribute("aria-pressed", String(dark));
+  })();
+</script>
+
 <script>
   import { mountThemeToggle } from "../scripts/theme";
 
@@ -75,6 +90,14 @@
   /* Without JS the button is inert; don't offer it. Ancient browsers that
      predate the `scripting` query fail open to a visible no-op button. */
   @media (scripting: none) {
+    .theme-toggle {
+      display: none;
+    }
+  }
+
+  /* Without `light-dark()` the site is permanently light (see global.css),
+     so the toggle would flip the bulb and nothing else. */
+  @supports not (color: light-dark(#000, #fff)) {
     .theme-toggle {
       display: none;
     }

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,111 @@
+---
+// Lightbulb artwork adapted from theme-toggles by Alfie Jones (MIT),
+// https://github.com/AlfieJones/theme-toggles. The coil and rays carry
+// pathLength="1" so a dash offset of one full length "draws them out".
+---
+
+<button class="theme-toggle" type="button" aria-label="Dark mode">
+  <svg
+    class="h-8 w-8"
+    viewBox="0 0 32 32"
+    stroke-width="2"
+    stroke="currentColor"
+    fill="currentColor"
+    stroke-linecap="round"
+    aria-hidden="true"
+  >
+    <path
+      stroke-width="1"
+      d="M9.4 9.9c1.8-1.8 4.1-2.7 6.6-2.7 5.1 0 9.3 4.2 9.3 9.3 0 2.3-.8 4.4-2.3 6.1-.7.8-2 2.8-2.5 4.4 0 .2-.2.4-.5.4-.2 0-.4-.2-.4-.5v-.1c.5-1.8 2-3.9 2.7-4.8 1.4-1.5 2.1-3.5 2.1-5.6 0-4.7-3.7-8.5-8.4-8.5-2.3 0-4.4.9-5.9 2.5-1.6 1.6-2.5 3.7-2.5 6 0 2.1.7 4 2.1 5.6.8.9 2.2 2.9 2.7 4.9 0 .2-.1.5-.4.5h-.1c-.2 0-.4-.1-.4-.4-.5-1.7-1.8-3.7-2.5-4.5-1.5-1.7-2.3-3.9-2.3-6.1 0-2.3 1-4.7 2.7-6.5z"
+    ></path>
+    <path d="M19.8 28.3h-7.6"></path>
+    <path d="M19.8 29.5h-7.6"></path>
+    <path d="M19.8 30.7h-7.6"></path>
+    <path
+      class="bulb-coil"
+      pathLength="1"
+      fill="none"
+      d="M14.6 27.1c0-3.4 0-6.8-.1-10.2-.2-1-1.1-1.7-2-1.7-1.2-.1-2.3 1-2.2 2.3.1 1 .9 1.9 2.1 2h7.2c1.1-.1 2-1 2.1-2 .1-1.2-1-2.3-2.2-2.3-.9 0-1.7.7-2 1.7 0 3.4 0 6.8-.1 10.2"
+    ></path>
+    <g class="bulb-rays">
+      <path pathLength="1" d="M16 6.4V1.3"></path>
+      <path pathLength="1" d="M26.3 15.8h5.1"></path>
+      <path pathLength="1" d="m22.6 9 3.7-3.6"></path>
+      <path pathLength="1" d="M9.4 9 5.7 5.4"></path>
+      <path pathLength="1" d="M5.7 15.8H.6"></path>
+    </g>
+  </svg>
+</button>
+
+<script>
+  import { mountThemeToggle } from "../scripts/theme";
+
+  const button = document.querySelector<HTMLButtonElement>(".theme-toggle");
+  if (button) mountThemeToggle(button);
+</script>
+
+<style>
+  .theme-toggle {
+    display: inline-flex;
+    margin: calc(-1 * var(--link-enlargement));
+    padding: var(--link-enlargement);
+    border: 0;
+    border-radius: var(--radius-link);
+    background: transparent;
+    /* A utility control: sit at the muted tier (like the 404's homepage
+       link) and sharpen to full strength on interaction. Mixed opaque
+       because the icon's fill, stroke, and overlapping paths double-paint;
+       a translucent color compounds into a darker rim where layers stack. */
+    color: color-mix(in srgb, var(--color-fg) 55%, var(--color-bg));
+    cursor: pointer;
+    transition:
+      transform 150ms ease-out,
+      color 150ms ease-out;
+  }
+
+  .theme-toggle:hover,
+  .theme-toggle:focus-visible {
+    color: var(--color-fg);
+  }
+
+  .theme-toggle:active {
+    transform: scale(0.9);
+  }
+
+  /* Without JS the button is inert; don't offer it. Ancient browsers that
+     predate the `scripting` query fail open to a visible no-op button. */
+  @media (scripting: none) {
+    .theme-toggle {
+      display: none;
+    }
+  }
+
+  /* Bulb state is pure CSS: the mount script loads late, and a JS class
+     flip would flash a lit bulb at every system-dark visitor. `--bulb-on`
+     drains the coil and rays when the resolved theme is dark. */
+  .bulb-coil,
+  .bulb-rays path {
+    stroke-dasharray: 1.1;
+    stroke-dashoffset: calc(1 - var(--bulb-on, 1));
+    opacity: var(--bulb-on, 1);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .bulb-coil,
+    .bulb-rays path {
+      transition:
+        stroke-dashoffset 500ms,
+        opacity 500ms;
+    }
+  }
+
+  :global(:root[data-theme="dark"]) .theme-toggle {
+    --bulb-on: 0;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :global(:root:not([data-theme="light"])) .theme-toggle {
+      --bulb-on: 0;
+    }
+  }
+</style>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,4 +1,6 @@
 export const GA_MEASUREMENT_ID = "G-82TXQKPXNL";
+// Browser-chrome tint per theme; must match --color-bg in global.css.
+export const THEME_COLORS = { light: "#ffffff", dark: "#111111" };
 export const SITE_TITLE = "Dale French";
 // Deliberately not `staticIntro` (src/data/intro): this is a search/social
 // snippet, so it reads warmer and names both roles up front.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import BaseHead from "../components/BaseHead.astro";
+import SiteHeader from "../components/SiteHeader.astro";
 
 interface Props {
   title: string;
@@ -15,6 +16,7 @@ const { title, description } = Astro.props;
   </head>
   <body>
     <a href="#main" class="skip-link">Skip to content</a>
+    <SiteHeader />
     <slot />
   </body>
 </html>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -23,10 +23,8 @@ import { SITE_TITLE } from "../consts";
     flex-direction: column;
     row-gap: var(--hero-gap-y);
     background-color: var(--color-bg);
-    /* Reserve the SiteHeader overlay's vertical run, same as the hero. */
-    padding-top: calc(
-      var(--spacing-page-y-md) + var(--logo-size) + var(--hero-gap-y)
-    );
+    /* Reserve the SiteHeader overlay's run, same as the hero. */
+    padding-top: var(--header-run);
   }
 
   .not-found-text {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,4 @@
 ---
-import Brand from "../components/Brand.astro";
 import Layout from "../layouts/Layout.astro";
 import { SITE_TITLE } from "../consts";
 ---
@@ -8,9 +7,7 @@ import { SITE_TITLE } from "../consts";
   title={`Not found · ${SITE_TITLE}`}
   description="This page doesn’t exist."
 >
-  <main id="main" class="not-found px-page-x pt-page-y-md">
-    <Brand />
-
+  <main id="main" class="not-found px-page-x">
     <h1 class="not-found-text">
       Hmm.<br />There’s nothing here.
     </h1>
@@ -26,6 +23,10 @@ import { SITE_TITLE } from "../consts";
     flex-direction: column;
     row-gap: var(--hero-gap-y);
     background-color: var(--color-bg);
+    /* Reserve the SiteHeader overlay's vertical run, same as the hero. */
+    padding-top: calc(
+      var(--spacing-page-y-md) + var(--logo-size) + var(--hero-gap-y)
+    );
   }
 
   .not-found-text {

--- a/src/scripts/theme.test.ts
+++ b/src/scripts/theme.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveCurrentTheme, resolveToggle } from "./theme";
+
+describe("resolveCurrentTheme", () => {
+  it("honours a valid override regardless of the system", () => {
+    expect(resolveCurrentTheme("dark", false)).toBe("dark");
+    expect(resolveCurrentTheme("light", true)).toBe("light");
+  });
+
+  it("follows the system when there is no override", () => {
+    expect(resolveCurrentTheme(null, true)).toBe("dark");
+    expect(resolveCurrentTheme(null, false)).toBe("light");
+  });
+
+  it("ignores garbage stored by other tools or old versions", () => {
+    expect(resolveCurrentTheme("auto", true)).toBe("dark");
+    expect(resolveCurrentTheme("", false)).toBe("light");
+  });
+});
+
+describe("resolveToggle", () => {
+  it("stores an override when flipping away from the system theme", () => {
+    expect(resolveToggle("light", "light")).toEqual({
+      next: "dark",
+      stored: "dark",
+    });
+    expect(resolveToggle("dark", "dark")).toEqual({
+      next: "light",
+      stored: "light",
+    });
+  });
+
+  it("clears the override when flipping back to the system theme", () => {
+    expect(resolveToggle("dark", "light")).toEqual({
+      next: "light",
+      stored: null,
+    });
+    expect(resolveToggle("light", "dark")).toEqual({
+      next: "dark",
+      stored: null,
+    });
+  });
+});

--- a/src/scripts/theme.ts
+++ b/src/scripts/theme.ts
@@ -1,0 +1,93 @@
+import { THEME_COLORS } from "../consts";
+
+export type Theme = "light" | "dark";
+
+const STORAGE_KEY = "theme";
+
+/**
+ * The effective theme for a stored override + system preference. Anything
+ * but a valid override (missing, or garbage someone wrote to localStorage)
+ * falls through to the system.
+ */
+export function resolveCurrentTheme(
+  override: string | null,
+  systemDark: boolean,
+): Theme {
+  if (override === "light" || override === "dark") return override;
+  return systemDark ? "dark" : "light";
+}
+
+/**
+ * The state after a toggle press: always flip the visible theme, but only
+ * store an override while it disagrees with the system. Flipping back to
+ * the system's choice returns to following it, so a later OS switch isn't
+ * pinned to a stale preference.
+ */
+export function resolveToggle(
+  current: Theme,
+  system: Theme,
+): { next: Theme; stored: Theme | null } {
+  const next: Theme = current === "dark" ? "light" : "dark";
+  return { next, stored: next === system ? null : next };
+}
+
+/**
+ * Wires the theme toggle. Colors and the bulb icon track the theme via CSS
+ * (`color-scheme` + `light-dark()`); this only maintains the override in
+ * localStorage / `data-theme`, the theme-color metas, and `aria-pressed`
+ * (pressed = dark active).
+ */
+export function mountThemeToggle(button: HTMLButtonElement): void {
+  const systemDark = window.matchMedia("(prefers-color-scheme: dark)");
+
+  const currentTheme = () =>
+    resolveCurrentTheme(
+      document.documentElement.dataset.theme ?? null,
+      systemDark.matches,
+    );
+
+  const syncPressed = () => {
+    button.setAttribute("aria-pressed", String(currentTheme() === "dark"));
+  };
+
+  button.addEventListener("click", () => {
+    const system: Theme = systemDark.matches ? "dark" : "light";
+    const { stored } = resolveToggle(currentTheme(), system);
+
+    if (stored) {
+      document.documentElement.dataset.theme = stored;
+    } else {
+      delete document.documentElement.dataset.theme;
+    }
+    try {
+      if (stored) {
+        localStorage.setItem(STORAGE_KEY, stored);
+      } else {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch {
+      // Storage can be unavailable (private mode); the theme still applies
+      // for this visit.
+    }
+
+    // With an override, both metas pin to its color; without one, each meta
+    // falls back to its own `media` match again.
+    document
+      .querySelectorAll<HTMLMetaElement>('meta[name="theme-color"]')
+      .forEach((meta) => {
+        meta.content = stored
+          ? THEME_COLORS[stored]
+          : meta.media.includes("dark")
+            ? THEME_COLORS.dark
+            : THEME_COLORS.light;
+      });
+
+    syncPressed();
+  });
+
+  // When following the system, an OS-level switch flips the CSS on its own;
+  // only the ARIA state needs a nudge.
+  systemDark.addEventListener("change", syncPressed);
+
+  syncPressed();
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -26,6 +26,21 @@
 @import "./tokens.css";
 @import "./parallax.css";
 
+/* Theme-aware colors. The hex values in `@theme` above stay light-only on
+   purpose: they're the working palette for browsers without `light-dark()`
+   (a broken substitution would unset every color, not just dark mode).
+   This block is unlayered so it beats Tailwind's `theme` layer. The dark
+   `--color-bg` must match THEME_COLORS in consts.ts. */
+@supports (color: light-dark(#000, #fff)) {
+  :root {
+    --color-fg: light-dark(#000000, #ffffff);
+    --color-bg: light-dark(#ffffff, #111111);
+    --color-faded: light-dark(rgb(0 0 0 / 0.2), rgb(255 255 255 / 0.2));
+    --color-muted: light-dark(rgb(0 0 0 / 0.55), rgb(255 255 255 / 0.55));
+    --color-surface-faded: light-dark(rgb(255 255 255 / 0.2), rgb(0 0 0 / 0.2));
+  }
+}
+
 body {
   background-color: var(--color-bg);
   color: var(--color-fg);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,5 +1,5 @@
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
 
   --link-enlargement: 0.4rem;
   --link-outline: calc(var(--link-enlargement) / 2);
@@ -7,21 +7,38 @@
   --hero-gap-y: clamp(3rem, 4vw + 1.5rem, 5rem);
   --logo-size: clamp(3rem, 4.5vw + 1rem, 4.5rem);
 
+  /* The vertical run of the SiteHeader overlay plus the gap under it.
+     Hero and 404 reserve this as padding-top so the overlay lands where
+     their brand row used to sit. */
+  --header-run: calc(
+    var(--spacing-page-y-md) + var(--logo-size) + var(--hero-gap-y)
+  );
+
   /* Fluid type scale, largest to smallest. */
   --hero-text: clamp(2.25rem, 5.5vw + 1rem, 4.5rem);
   --contact-text: clamp(1.5rem, 2.5vw + 0.75rem, 2rem);
   --footnote-text: clamp(1.125rem, 1.5vw + 0.5rem, 1.5rem);
 }
 
-/* An explicit user choice (set pre-paint by the BaseHead inline script and
-   toggled by ThemeToggle) pins the scheme; no attribute means follow the
-   system, which is what makes the `light-dark()` tokens flip. */
-:root[data-theme="light"] {
-  color-scheme: light;
-}
+/* Dark mode exists only where `light-dark()` does (the token flip in
+   global.css); the same guard here keeps `color-scheme` in step, so a
+   browser stuck on the light palette can't sprout dark UA scrollbars and
+   form controls. */
+@supports (color: light-dark(#000, #fff)) {
+  :root {
+    color-scheme: light dark;
+  }
 
-:root[data-theme="dark"] {
-  color-scheme: dark;
+  /* An explicit user choice (set pre-paint by the BaseHead inline script
+     and toggled by ThemeToggle) pins the scheme; no attribute means follow
+     the system, which is what makes the `light-dark()` tokens flip. */
+  :root[data-theme="light"] {
+    color-scheme: light;
+  }
+
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+  }
 }
 
 ::selection {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,5 +1,5 @@
 :root {
-  color-scheme: light;
+  color-scheme: light dark;
 
   --link-enlargement: 0.4rem;
   --link-outline: calc(var(--link-enlargement) / 2);
@@ -11,6 +11,17 @@
   --hero-text: clamp(2.25rem, 5.5vw + 1rem, 4.5rem);
   --contact-text: clamp(1.5rem, 2.5vw + 0.75rem, 2rem);
   --footnote-text: clamp(1.125rem, 1.5vw + 0.5rem, 1.5rem);
+}
+
+/* An explicit user choice (set pre-paint by the BaseHead inline script and
+   toggled by ThemeToggle) pins the scheme; no attribute means follow the
+   system, which is what makes the `light-dark()` tokens flip. */
+:root[data-theme="light"] {
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
 }
 
 ::selection {


### PR DESCRIPTION
## Description

The site was light-only. This adds a hand-built lightbulb theme toggle (artwork adapted from theme-toggles, MIT) on the right of a new header row. The system color scheme is the default, an explicit choice persists in localStorage, and there is no flash of the wrong theme on first load.

## What Changed

- Theming is CSS-first: color tokens are `light-dark()` pairs flipped by `color-scheme`, guarded by `@supports` so browsers without `light-dark()` keep the light palette. No `data-theme` attribute means follow the system, so system-default visitors get a correct first paint with no JS.
- An inline head script applies a stored override before first paint; the single `theme-color` meta became two media-scoped ones kept in sync on toggle.
- New `ThemeToggle` bulb: coil and rays draw out via a `stroke-dashoffset` transition (reduced-motion aware). Icon state is driven by CSS selectors on the resolved theme, so it renders correctly before any JS runs. Sits at an opaque muted grey, sharpening on hover/focus.
- Toggle logic lives in `src/scripts/theme.ts` with Vitest coverage: flipping back to the system's theme clears the override instead of pinning it.
- `SiteHeader` overlays the hero from outside the parallax depth layer. Chromium's hit-testing drops clicks inside the hero's `scale(3) translateZ(-2px)` transform (this also broke the existing Brand link), so interactive elements can't live there; recorded as an AGENTS.md gotcha. Hero and 404 reserve the header's space in their padding, so the layout is unchanged.
- Logo tiles and footer washes now derive from theme vars instead of hardcoded black/white.

## How to QA

1. `pnpm dev`, open the site with system dark mode on: the site renders dark immediately, bulb unlit.
2. Click the bulb: theme flips to light, bulb lights up, choice survives a reload with no flash.
3. Click again: theme returns to dark and the override clears (`localStorage.theme` removed), so an OS appearance switch flips the site again.
4. Tab to the toggle: focus ring shows, Enter/Space toggles, `aria-pressed` tracks dark.
5. Check `/404`: same header, same behavior. Click the logo: it navigates home (it didn't before this PR).

## Screenshots

_Light and dark header states to be added._